### PR TITLE
(dataframe) made boost::json header only dep.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ find_package(Threads REQUIRED)
 
 #
 # Boost
-find_package(Boost 1.75 REQUIRED COMPONENTS json)
+find_package(Boost 1.75 REQUIRED COMPONENTS)
 
 ### Require out-of-source builds
 file(TO_CMAKE_PATH "${PROJECT_BINARY_DIR}/CMakeLists.txt" LOC_PATH)

--- a/examples/dataframe/CMakeLists.txt
+++ b/examples/dataframe/CMakeLists.txt
@@ -8,7 +8,7 @@ function ( add_df_example example_name )
   target_link_libraries(${example_name} libcliprt)
   endfunction()
 
-
+include_directories(${Boost_INCLUDE_DIRS}) 
 
 add_library(libcliprt STATIC clip)
 target_link_libraries(libcliprt ${Boost_LIBRARIES})

--- a/examples/dataframe/clip.cpp
+++ b/examples/dataframe/clip.cpp
@@ -3,6 +3,7 @@
 #include <fstream>
 
 #include "clip.hpp"
+#include <boost/json/src.hpp>
 
 namespace boostjsn = boost::json;
 
@@ -190,7 +191,6 @@ int columnIndex(const std::vector<std::string>& all, const std::string& colname)
   return std::distance(aa, pos);
 }
 
-[[noreturn]]
 bool fail(const std::string& msg)
 {
   clippy_assert(false, msg);

--- a/examples/dataframe/clip.hpp
+++ b/examples/dataframe/clip.hpp
@@ -25,7 +25,6 @@ void setValueIfAvail(const boost::json::value& args, const char* key, int& val);
 
 int columnIndex(const std::vector<std::string>& all, const std::string& colname);
 
-[[noreturn]]
 bool fail(const std::string& msg);
 
 namespace


### PR DESCRIPTION
The current repo cannot be built on binder because the cmake does not find the json dynamic library.

This update modifies the code to use a header only version of boost::son